### PR TITLE
Fix code scanning alert no. 1: Multiplication result converted to larger type

### DIFF
--- a/tpws/tpws.c
+++ b/tpws/tpws.c
@@ -1132,7 +1132,7 @@ static bool set_ulimit(void)
 		// additional 1/2 for unpaired remote legs sending buffers
 		// 16 for listen_fd, epoll, hostlist, ...
 #ifdef SPLICE_PRESENT
-		fdmax = (params.nosplice ? 2 : (params.tamper && !params.tamper_lim ? 4 : 6)) * params.maxconn;
+		fdmax = (rlim_t)(params.nosplice ? 2 : (params.tamper && !params.tamper_lim ? 4 : 6)) * (rlim_t)params.maxconn;
 #else
 		fdmax = 2 * params.maxconn;
 #endif


### PR DESCRIPTION
Fixes [https://github.com/SashaXser/zapret/security/code-scanning/1](https://github.com/SashaXser/zapret/security/code-scanning/1)

To fix the problem, we need to ensure that the multiplication is performed using the larger type `rlim_t` to avoid overflow. This can be achieved by casting the operands to `rlim_t` before performing the multiplication. This ensures that the multiplication is done in the larger type, preventing overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
