### PR TITLE
Fix code scanning alert no. 2: Incorrect return-value check for a 'scanf'-like function

### DIFF
--- a/tpws/tpws.c
+++ b/tpws/tpws.c
@@ -1087,7 +1087,7 @@ static bool read_system_maxfiles(rlim_t *maxfile)
 		return false;
 	n=fscanf(F,"%ju",&um);
 	fclose(F);
-	if (!n)	return false;
+	if (n != 1)	return false;
 	*maxfile = (rlim_t)um;
 	return true;
 #elif defined(BSD)


### PR DESCRIPTION
Fixes [https://github.com/SashaXser/zapret/security/code-scanning/2](https://github.com/SashaXser/zapret/security/code-scanning/2)

To fix the problem, we need to ensure that the return value of `fscanf` is checked against the expected number of arguments, which is 1 in this case. This will ensure that both `EOF` and zero are handled correctly. Specifically, we should check if the return value is less than 1, which covers both zero and `EOF`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
