### PR TITLE
Fix code scanning alert no. 3: Wrong type of arguments to formatting function

### DIFF
--- a/nfq/desync.c
+++ b/nfq/desync.c
@@ -1440,7 +1440,7 @@ static uint8_t dpi_desync_tcp_packet_play(bool replay, size_t reasm_offset, uint
 
 					if (seqovl_pos>=split_pos)
 					{
-						DLOG("seqovl>=split_pos (%u>=%zu). cancelling seqovl.\n",seqovl_pos,split_pos);
+						DLOG("seqovl>=split_pos (%lu>=%zu). cancelling seqovl.\n",seqovl_pos,split_pos);
 						seqovl = 0;
 					}
 					else


### PR DESCRIPTION
Fixes [https://github.com/SashaXser/zapret/security/code-scanning/3](https://github.com/SashaXser/zapret/security/code-scanning/3)

To fix the problem, we need to ensure that the format specifier matches the type of the argument. Since `seqovl_pos` is of type `unsigned long`, we should use the format specifier `%lu` instead of `%u`.

- Change the format specifier from `%u` to `%lu` in the `DLOG` function call on line 1443.
- This change should be made in the file `nfq/desync.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
